### PR TITLE
Add date parsing and manipulation for e-mail templates (#1451)

### DIFF
--- a/models/template_context.go
+++ b/models/template_context.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path"
 	"text/template"
+	"time"
 )
 
 // TemplateContext is an interface that allows both campaigns and email
@@ -24,6 +25,7 @@ type PhishingTemplateContext struct {
 	TrackingURL string
 	RId         string
 	BaseURL     string
+	Now         time.Time
 	BaseRecipient
 }
 
@@ -66,6 +68,7 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 		Tracker:       "<img alt='' style='display: none' src='" + trackingURL.String() + "'/>",
 		From:          fn,
 		RId:           rid,
+		Now:           time.Now(),
 	}, nil
 }
 
@@ -73,7 +76,12 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 // template body and data.
 func ExecuteTemplate(text string, data interface{}) (string, error) {
 	buff := bytes.Buffer{}
-	tmpl, err := template.New("template").Parse(text)
+	funcMap := template.FuncMap{
+		"date":     time.Parse,
+		"duration": time.ParseDuration,
+		"location": time.LoadLocation,
+	}
+	tmpl, err := template.New("template").Funcs(funcMap).Parse(text)
 	if err != nil {
 		return buff.String(), err
 	}

--- a/models/template_context_test.go
+++ b/models/template_context_test.go
@@ -43,5 +43,6 @@ func (s *ModelsSuite) TestNewTemplateContext(c *check.C) {
 	expected.Tracker = "<img alt='' style='display: none' src='" + expected.TrackingURL + "'/>"
 	got, err := NewPhishingTemplateContext(ctx, r.BaseRecipient, r.RId)
 	c.Assert(err, check.Equals, nil)
+	expected.Now = got.Now
 	c.Assert(got, check.DeepEquals, expected)
 }


### PR DESCRIPTION
* Add date parsing and manipulation for e-mail templates

* Add duration parser to date handling in e-mail templates

* Correct whitespace usage in template_context.go